### PR TITLE
Mic Off -> Mic is Off

### DIFF
--- a/src/pipecat_cli/templates/client/vanilla-js-vite/index.html
+++ b/src/pipecat_cli/templates/client/vanilla-js-vite/index.html
@@ -20,7 +20,7 @@
       </div>
       <div class="controls">
         <button id="mic-btn" class="control-btn" disabled>
-          🎤 <span id="mic-status">Mic Off</span>
+          🎤 <span id="mic-status">Mic is Off</span>
         </button>
         <button id="connect-btn" class="connect-btn">Connect</button>
       </div>

--- a/src/pipecat_cli/templates/client/vanilla-js-vite/src/app.js
+++ b/src/pipecat_cli/templates/client/vanilla-js-vite/src/app.js
@@ -180,7 +180,7 @@ class VoiceChatClient {
   }
 
   updateMicButton(enabled) {
-    this.micStatus.textContent = enabled ? 'Mic On' : 'Mic Off';
+    this.micStatus.textContent = enabled ? 'Mic is On' : 'Mic is Off';
     this.micBtn.style.backgroundColor = enabled ? '#10b981' : '#1f2937';
   }
 


### PR DESCRIPTION
it's a little confusing that the `connect/disconnect` button's wording and coloring indicates what the button will do if you click it (not the current state).
whereas the Mic On/Off button states the current state (not what will happen if you click it).

adding the `is` in `Mic is Off`/ `Mic is On` makes it clearer.

<img width="226" height="63" alt="buttons" src="https://github.com/user-attachments/assets/2a8dea7d-bd8a-42ef-9631-3495884ebdea" />
<img width="220" height="69" alt="onmic" src="https://github.com/user-attachments/assets/c6f04ec1-207f-4553-9bf5-21f29141e703" />

the clearest option is probably `mute/unmute` with icon like this:
<img width="131" height="66" alt="turnoffmute" src="https://github.com/user-attachments/assets/1559570e-a593-492d-a36c-ff57f4d1afea" />
but adding `is` is a faster change :D