### PR TITLE
conditionally import transports in client

### DIFF
--- a/src/pipecat_cli/templates/client/vanilla-js-vite/src/app.js
+++ b/src/pipecat_cli/templates/client/vanilla-js-vite/src/app.js
@@ -1,6 +1,4 @@
 import { PipecatClient, RTVIEvent } from '@pipecat-ai/client-js';
-import { DailyTransport } from '@pipecat-ai/daily-transport';
-import { SmallWebRTCTransport } from '@pipecat-ai/small-webrtc-transport';
 import {
   AVAILABLE_TRANSPORTS,
   DEFAULT_TRANSPORT,
@@ -34,8 +32,10 @@ class VoiceChatClient {
       option.textContent =
         transport.charAt(0).toUpperCase() + transport.slice(1);
       if (transport === 'smallwebrtc') {
+        import { SmallWebRTCTransport } from '@pipecat-ai/small-webrtc-transport';
         option.textContent = 'SmallWebRTC';
       } else if (transport === 'daily') {
+        import { DailyTransport } from '@pipecat-ai/daily-transport';
         option.textContent = 'Daily';
       }
       this.transportSelect.appendChild(option);


### PR DESCRIPTION
looks like we conditionally include transports in package.json but always include both transports in vanilla-js-vite `app.js`.

not sure this is the best way to conditionally import in `app.js`, but it should be handled somehow.

with this config:
```
  Server setup:
  • Go to server: cd server
  • Install dependencies: uv sync
  • Create .env file: cp .env.example .env
  • Edit .env and add your API keys
  • Run your bot:
     • SmallWebRTC: uv run bot.py

  Client setup:
  • Go to client: cd client
  • Install dependencies: npm install
  • Run dev server: npm run dev
```

I see this error in the client:
<img width="974" height="203" alt="transportimports" src="https://github.com/user-attachments/assets/e60fcd34-15ac-41b4-808e-569d3f2a0ebf" />
