### PR TITLE
Bump client template dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bumped client template dependencies:
+  - `@pipecat-ai/client-js` to 1.8.0 across the vanilla-js-vite, react-vite,
+    and react-nextjs templates.
+  - `@pipecat-ai/voice-ui-kit` to 0.10.0 in the react-vite and react-nextjs
+    templates.
+
 ## [1.1.0] - 2026-04-29
 
 ### Added

--- a/src/pipecat_cli/templates/client/react-nextjs/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/react-nextjs/package.json.jinja2
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.7.0",
+    "@pipecat-ai/client-js": "^1.8.0",
     "@pipecat-ai/client-react": "^1.3.0",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
@@ -18,7 +18,7 @@
     "@pipecat-ai/small-webrtc-transport": "^1.10.0",
 {%- endif %}
 {%- endfor %}
-    "@pipecat-ai/voice-ui-kit": "^0.9.0",
+    "@pipecat-ai/voice-ui-kit": "^0.10.0",
     "next": "^16",
     "react": "^19",
     "react-dom": "^19"

--- a/src/pipecat_cli/templates/client/react-vite/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/react-vite/package.json.jinja2
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.7.0",
+    "@pipecat-ai/client-js": "^1.8.0",
     "@pipecat-ai/client-react": "^1.3.0",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
@@ -19,7 +19,7 @@
     "@pipecat-ai/small-webrtc-transport": "^1.10.0",
 {%- endif %}
 {%- endfor %}
-    "@pipecat-ai/voice-ui-kit": "^0.9.0",
+    "@pipecat-ai/voice-ui-kit": "^0.10.0",
     "react": "^19",
     "react-dom": "^19"
   },

--- a/src/pipecat_cli/templates/client/vanilla-js-vite/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/vanilla-js-vite/package.json.jinja2
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.7.0"
+    "@pipecat-ai/client-js": "^1.8.0"
 {%- for transport in transports -%}
 {%- if transport.value == 'daily' %},
     "@pipecat-ai/daily-transport": "^1.6.1"


### PR DESCRIPTION
- Bumped client template dependencies:
  - `@pipecat-ai/client-js` to 1.8.0 across the vanilla-js-vite, react-vite,
    and react-nextjs templates.
  - `@pipecat-ai/voice-ui-kit` to 0.10.0 in the react-vite and react-nextjs
    templates.