### PR TITLE
Bump client SDK versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3.11.
 
 - Bumped client template dependencies:
-  - `@pipecat-ai/client-js` to 1.8.0 across the vanilla-js-vite, react-vite,
+  - `@pipecat-ai/client-js` to 1.9.0 across the vanilla-js-vite, react-vite,
     and react-nextjs templates.
-  - `@pipecat-ai/client-react` to 1.4.0 across the react-vite and react-nextjs
+  - `@pipecat-ai/client-react` to 1.5.0 across the react-vite and react-nextjs
     templates.
   - `@pipecat-ai/voice-ui-kit` to 0.11.0 in the react-vite and react-nextjs
     templates.
-  - `"@pipecat-ai/small-webrtc-transport"` to 1.10.1 across the vanilla-js-vite,
+  - `"@pipecat-ai/daily-transport"` to 1.6.4 across the vanilla-js-vite,
+    react-vite, and react-nextjs templates.
+  - `"@pipecat-ai/small-webrtc-transport"` to 1.10.2 across the vanilla-js-vite,
     react-vite, and react-nextjs templates.
 
 ## [1.1.0] - 2026-04-29

--- a/src/pipecat_cli/templates/client/react-nextjs/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/react-nextjs/package.json.jinja2
@@ -9,13 +9,13 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.8.0",
-    "@pipecat-ai/client-react": "^1.4.0",
+    "@pipecat-ai/client-js": "^1.9.0",
+    "@pipecat-ai/client-react": "^1.5.0",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
-    "@pipecat-ai/daily-transport": "^1.6.3",
+    "@pipecat-ai/daily-transport": "^1.6.4",
 {%- elif transport.value == 'smallwebrtc' %}
-    "@pipecat-ai/small-webrtc-transport": "^1.10.1",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.2",
 {%- endif %}
 {%- endfor %}
     "@pipecat-ai/voice-ui-kit": "^0.11.0",

--- a/src/pipecat_cli/templates/client/react-vite/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/react-vite/package.json.jinja2
@@ -10,13 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.8.0",
-    "@pipecat-ai/client-react": "^1.4.0",
+    "@pipecat-ai/client-js": "^1.9.0",
+    "@pipecat-ai/client-react": "^1.5.0",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
-    "@pipecat-ai/daily-transport": "^1.6.3",
+    "@pipecat-ai/daily-transport": "^1.6.4",
 {%- elif transport.value == 'smallwebrtc' %}
-    "@pipecat-ai/small-webrtc-transport": "^1.10.1",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.2",
 {%- endif %}
 {%- endfor %}
     "@pipecat-ai/voice-ui-kit": "^0.11.0",

--- a/src/pipecat_cli/templates/client/vanilla-js-vite/package.json.jinja2
+++ b/src/pipecat_cli/templates/client/vanilla-js-vite/package.json.jinja2
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.8.0"
+    "@pipecat-ai/client-js": "^1.9.0"
 {%- for transport in transports -%}
 {%- if transport.value == 'daily' %},
-    "@pipecat-ai/daily-transport": "^1.6.3"
+    "@pipecat-ai/daily-transport": "^1.6.4"
 {%- elif transport.value == 'smallwebrtc' %},
-    "@pipecat-ai/small-webrtc-transport": "^1.10.1"
+    "@pipecat-ai/small-webrtc-transport": "^1.10.2"
 {%- endif %}
 {%- endfor %}
   },


### PR DESCRIPTION
- Bumped client template dependencies:
  - `@pipecat-ai/client-js` to 1.9.0 across the vanilla-js-vite, react-vite,
    and react-nextjs templates.
  - `@pipecat-ai/client-react` to 1.5.0 across the react-vite and react-nextjs
    templates.
  - `"@pipecat-ai/daily-transport"` to 1.6.4 across the vanilla-js-vite,
    react-vite, and react-nextjs templates.
  - `"@pipecat-ai/small-webrtc-transport"` to 1.10.2 across the vanilla-js-vite,
    react-vite, and react-nextjs templates.