### PR TITLE
Format generated Python reliably; lint with UP rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pipecat init` now reliably formats generated Python files. The post-
+  generation Ruff step shelled out to a bare `ruff` on `PATH`, which is not
+  exposed when the CLI is installed as an isolated tool (`uv tool install` /
+  `pipx`) — only the `pipecat`/`pc` scripts are. In that case formatting was
+  silently skipped, shipping raw template output. It now invokes the Ruff
+  binary bundled with the CLI's dependencies, and surfaces a warning if
+  formatting cannot run instead of failing silently.
+
 ### Changed
+
+- Generated projects now enable Ruff's `UP` (pyupgrade) lint rules in addition
+  to import sorting (`I`), so user-run linting modernizes generated code.
 
 - Bumped client template dependencies:
   - `@pipecat-ai/client-js` to 1.10.0 across the vanilla-js-vite, react-vite,

--- a/src/pipecat_cli/generators/project.py
+++ b/src/pipecat_cli/generators/project.py
@@ -8,6 +8,7 @@
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import questionary
@@ -677,22 +678,56 @@ class ProjectGenerator:
         rendered = template.render(**context)
         dest_file.write_text(rendered, encoding="utf-8")
 
+    def _ruff_command(self) -> list[str]:
+        """Resolve the command used to invoke Ruff.
+
+        Ruff is a hard dependency of the CLI, so it is always installed in the
+        same environment. We invoke the bundled binary directly (rather than a
+        bare ``ruff`` on PATH), because when the CLI is installed as an isolated
+        tool (``uv tool install`` / ``pipx``) only the ``pipecat``/``pc`` scripts
+        are exposed on PATH — Ruff's console script is not.
+        """
+        try:
+            from ruff.__main__ import find_ruff_bin
+
+            return [find_ruff_bin()]
+        except (ImportError, FileNotFoundError):
+            # Fall back to invoking Ruff as a module via the current interpreter.
+            return [sys.executable, "-m", "ruff"]
+
     def _format_python_files(self, project_path: Path) -> None:
         """Format generated Python files with Ruff."""
+        ruff = self._ruff_command()
         try:
             # Run ruff format on the project directory
-            subprocess.run(
-                ["ruff", "format", str(project_path)],
+            fmt = subprocess.run(
+                [*ruff, "format", str(project_path)],
                 capture_output=True,
-                check=False,  # Don't raise if ruff isn't installed
+                text=True,
+                check=False,
             )
 
             # Run ruff check --fix to organize imports
-            subprocess.run(
-                ["ruff", "check", "--fix", "--select", "I", str(project_path)],
+            imports = subprocess.run(
+                [*ruff, "check", "--fix", "--select", "I", str(project_path)],
                 capture_output=True,
+                text=True,
                 check=False,
             )
-        except FileNotFoundError:
-            # Ruff not installed, skip formatting
-            pass
+        except (FileNotFoundError, OSError) as e:
+            console.print(
+                f"[yellow]⚠️  Could not run Ruff to format generated files ({e}). "
+                "Generated Python may be unformatted; run 'ruff format' manually.[/yellow]"
+            )
+            return
+
+        # Surface non-zero exits instead of silently shipping unformatted code.
+        for label, result in (("format", fmt), ("check --fix", imports)):
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "").strip()
+                console.print(
+                    f"[yellow]⚠️  Ruff {label} exited with code {result.returncode}; "
+                    "generated Python may be unformatted."
+                    + (f"\n{detail}" if detail else "")
+                    + "[/yellow]"
+                )

--- a/src/pipecat_cli/templates/server/pyproject.toml.jinja2
+++ b/src/pipecat_cli/templates/server/pyproject.toml.jinja2
@@ -26,4 +26,4 @@ dev = [
 [tool.ruff]
 line-length = 100
 [tool.ruff.lint]
-select = ["I"]
+select = ["I", "UP"]

--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -94,6 +94,26 @@ def validate_imports_resolvable(bot_file_path):
     return True, imports
 
 
+def assert_server_ruff_clean(server_path):
+    """Assert generated Python under server_path is already Ruff-formatted.
+
+    Uses the Ruff binary bundled with the CLI's dependencies (the same one
+    ``ProjectGenerator._format_python_files`` resolves), so the check does not
+    depend on ``ruff`` being on PATH.
+    """
+    from ruff.__main__ import find_ruff_bin
+
+    result = subprocess.run(
+        [find_ruff_bin(), "format", "--check", str(server_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Generated Python under {server_path} is not Ruff-formatted:\n"
+        f"{result.stdout}{result.stderr}"
+    )
+
+
 # Test configurations for different transport types
 TEST_CONFIGS = [
     # WebRTC Transports - Cascade
@@ -448,6 +468,11 @@ def test_project_generation(config_data, temp_output_dir):
     is_valid, imports = validate_imports_resolvable(bot_file)
     assert is_valid, "bot.py should have valid Pipecat imports"
 
+    # Generated Python must be Ruff-formatted. Regression guard: the formatting
+    # step used to silently no-op when `ruff` was not on PATH, shipping the raw
+    # (mis-indented, unsorted-imports) template output.
+    assert_server_ruff_clean(project_path / "server")
+
     # Verify bot.py structure
     bot_content = bot_file.read_text()
     assert "async def run_bot" in bot_content, "bot.py should have run_bot function"
@@ -653,6 +678,66 @@ def test_generation_uses_utf8_on_windows_locale(monkeypatch, temp_output_dir):
     # survived the cp1252-simulating environment.
     assert "→" in bot.read_text(encoding="utf-8")
     assert "→" in readme.read_text(encoding="utf-8")
+
+
+def test_generated_python_formatted_without_ruff_on_path(monkeypatch, tmp_path, temp_output_dir):
+    """Regression test: generated Python is formatted even when `ruff` is off PATH.
+
+    When the CLI is installed as an isolated tool (``uv tool install`` /
+    ``pipx``), only the ``pipecat``/``pc`` scripts land on PATH — Ruff's console
+    script does not. ``_format_python_files`` must still run by resolving the
+    bundled Ruff binary directly. Previously it shelled out to a bare ``ruff``
+    and silently skipped formatting via ``FileNotFoundError``, shipping raw
+    template output.
+    """
+    import shutil as _shutil
+
+    # Point PATH at an empty directory so a bare `ruff` lookup fails on any
+    # platform — mirroring an isolated tool install where ruff isn't exposed.
+    empty_dir = tmp_path / "empty_path"
+    empty_dir.mkdir()
+    monkeypatch.setenv("PATH", str(empty_dir))
+    assert _shutil.which("ruff") is None, "test setup: ruff should not be on PATH"
+
+    config = ProjectConfig(
+        project_name="fmt-no-path",
+        bot_type="web",
+        transports=["daily"],
+        mode="cascade",
+        stt_service="deepgram_stt",
+        llm_service="openai_llm",
+        tts_service="cartesia_tts",
+    )
+    ProjectGenerator(config).generate(output_dir=temp_output_dir, non_interactive=True)
+
+    assert_server_ruff_clean(temp_output_dir / "fmt-no-path" / "server")
+
+
+def test_format_warns_when_ruff_cannot_run(monkeypatch, temp_output_dir, capsys):
+    """Regression test: a formatting failure warns instead of being silently swallowed.
+
+    The old code caught ``FileNotFoundError`` and ``pass``ed, so a missing or
+    broken Ruff produced unformatted output with no signal to the user.
+    """
+    config = ProjectConfig(
+        project_name="warn-test",
+        bot_type="web",
+        transports=["daily"],
+        mode="cascade",
+        stt_service="deepgram_stt",
+        llm_service="openai_llm",
+        tts_service="cartesia_tts",
+    )
+    generator = ProjectGenerator(config)
+    # Force Ruff resolution to a non-existent binary so the subprocess raises
+    # FileNotFoundError — the case that used to be silently ignored.
+    monkeypatch.setattr(generator, "_ruff_command", lambda: ["pipecat-cli-no-such-ruff-binary"])
+    generator.generate(output_dir=temp_output_dir, non_interactive=True)
+
+    captured = capsys.readouterr()
+    assert "Could not run Ruff" in captured.out, (
+        f"expected a Ruff warning on stdout, got:\n{captured.out}"
+    )
 
 
 def test_invalid_service_combination():


### PR DESCRIPTION
## Problem

`pipecat init` is supposed to Ruff-format generated Python (`ProjectGenerator._format_python_files`), but the output often arrives raw — mis-indented blocks, stray blank lines, unsorted imports.

Root cause: the formatting step shelled out to a **bare `ruff`** on `PATH`. `ruff` *is* a hard runtime dependency, so it's installed alongside the CLI — but when the CLI is installed as an isolated tool (`uv tool install` / `pipx`), only the declared `pipecat`/`pc` scripts are exposed on `PATH`. Ruff's console script lives in the tool's private venv and isn't reachable, so `subprocess.run(["ruff", ...])` raised `FileNotFoundError`, which was caught and `pass`ed — formatting silently skipped. (It worked in a dev checkout because `.venv/bin` is on `PATH`, which is why it wasn't caught.)

## Changes

- **Resolve the bundled Ruff** via `ruff.__main__.find_ruff_bin()`, falling back to `[sys.executable, "-m", "ruff"]` — no longer depends on `ruff` being on `PATH`.
- **No more silent failures**: capture Ruff's output/return code and print a warning if it can't run or exits non-zero, instead of shipping unformatted code invisibly.
- **Enable `UP` (pyupgrade) lint rules** in generated projects' `pyproject.toml` alongside import sorting (`I`).

## Tests

Added regression guards in `tests/test_project_generation.py`:
- The existing 28-config generation sweep now also asserts each generated `server/` is Ruff-clean (`ruff format --check`).
- `test_generated_python_formatted_without_ruff_on_path` — points `PATH` at an empty dir (verifies `ruff` is genuinely unreachable) and confirms output is still formatted. Guards the bundled-binary resolution.
- `test_format_warns_when_ruff_cannot_run` — confirms a warning is emitted when Ruff can't run.

Verified these tests go **red** against the old bare-`ruff` behavior and **green** with the fix.

## Verification

Full real-world reproduction before/after: built the wheel, `uv tool install`'d it into throwaway dirs, ran `pc init` in a shell with `ruff` absent from `PATH` → exit 0, no warning, fully formatted `bot.py`, `ruff format --check` reports clean.

Suite: 418 passed (was 416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)