### PR TITLE
Support `pc init .` to scaffold a project in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `pc init` now accepts an optional target directory. Passing a path — for
+  example `pc init .` — scaffolds the project **directly into that directory**
+  instead of nesting it under a `<project-name>/` subfolder (the same convention
+  as `npm create vite@latest .`). The project name defaults to the target
+  directory's basename, and `--name` still overrides it. Omitting the argument
+  keeps the existing behavior, so this is non-breaking.
+
 ### Changed
 
 - Generated bots now configure their transport through a single

--- a/src/pipecat_cli/commands/init.py
+++ b/src/pipecat_cli/commands/init.py
@@ -18,8 +18,6 @@ from pipecat_cli.registry.service_metadata import ServiceRegistry
 
 console = Console()
 
-init_app = typer.Typer(invoke_without_command=True)
-
 
 def _list_options_callback(value: bool):
     """Print available options as JSON and exit."""
@@ -45,9 +43,12 @@ def _list_options_callback(value: bool):
     raise typer.Exit(0)
 
 
-@init_app.callback(invoke_without_command=True)
 def init_command(
-    ctx: typer.Context,
+    target: str | None = typer.Argument(
+        None,
+        help="Target directory; use '.' to scaffold into the current directory "
+        "(no <name> subfolder). Omit to create a <name> subfolder.",
+    ),
     output_dir: Path | None = typer.Option(
         None, "--output", "-o", help="Output directory (defaults to current directory)"
     ),
@@ -127,18 +128,46 @@ def init_command(
 
     Examples:
         pc init                                          # Interactive wizard
+        pc init .                                        # Scaffold into the current dir
         pc init --name my-bot --bot-type web \\
           --transport daily --mode cascade \\
           --stt deepgram_stt --llm openai_llm \\
           --tts cartesia_tts                             # Non-interactive
+        pc init . --bot-type web -t daily -m cascade \\
+          --stt deepgram_stt --llm openai_llm \\
+          --tts cartesia_tts                             # In-place, name from dir
         pc init --config project-config.json             # From config file
         pc init --name my-bot ... --dry-run              # Preview config as JSON
     """
-    if ctx.invoked_subcommand is not None:
-        return
+    # `quickstart` is dispatched here rather than as a subcommand: a positional arg on a
+    # Typer *group* can't be followed by options (Click stops parsing at the first
+    # positional), which would break `pc init . --bot-type ...`. Keeping `init` a plain
+    # command and routing the `quickstart` token preserves `pc init quickstart [-o ...]`.
+    if target == "quickstart":
+        return quickstart_command(output_dir=output_dir)
 
     try:
+        # Resolve the in-place target. A positional path is the exact destination
+        # (vite/django style); -o keeps its legacy "parent dir + name subfolder" meaning,
+        # so passing both is ambiguous.
+        in_place = target is not None
+        dest: Path | None = None
+        derived_name: str | None = None
+        if in_place:
+            if output_dir is not None:
+                console.print(
+                    "\n[red]Error: pass either a target directory or --output, not both.[/red]"
+                )
+                raise typer.Exit(1)
+            dest = Path(target).resolve()
+            derived_name = dest.name or "pipecat-app"
+
+        # In-place runs go non-interactive as soon as any non-interactive intent is
+        # present (the name can be derived from the directory). Scoped to in_place so
+        # no existing (no-positional) invocation changes behavior.
         non_interactive = name is not None or config is not None
+        if in_place and (name is not None or bot_type is not None or config is not None):
+            non_interactive = True
 
         if non_interactive:
             from pipecat_cli.config_validator import (
@@ -182,7 +211,7 @@ def init_command(
 
             try:
                 project_config = validate_and_build_config(
-                    name=name,
+                    name=name or derived_name,
                     bot_type=bot_type,
                     transport=transport,
                     mode=mode,
@@ -213,21 +242,23 @@ def init_command(
 
             # Generate project
             generator = ProjectGenerator(project_config)
-            project_path = generator.generate(output_dir, non_interactive=True)
+            project_path = generator.generate(
+                dest if in_place else output_dir, non_interactive=True, in_place=in_place
+            )
 
             # Show next steps
-            generator.print_next_steps(project_path)
+            generator.print_next_steps(project_path, in_place=in_place)
 
         else:
             # Interactive mode: ask questions
-            config_result = ask_project_questions()
+            config_result = ask_project_questions(default_name=derived_name)
 
             # Generate project
             generator = ProjectGenerator(config_result)
-            project_path = generator.generate(output_dir)
+            project_path = generator.generate(dest if in_place else output_dir, in_place=in_place)
 
             # Show next steps
-            generator.print_next_steps(project_path)
+            generator.print_next_steps(project_path, in_place=in_place)
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Project creation cancelled.[/yellow]")
@@ -242,21 +273,13 @@ def init_command(
         raise typer.Exit(1)
 
 
-@init_app.command("quickstart")
-def quickstart_command(
-    output_dir: Path | None = typer.Option(
-        None, "--output", "-o", help="Output directory (defaults to current directory)"
-    ),
-):
+def quickstart_command(output_dir: Path | None = None):
     """
     Create a new Pipecat project with quickstart defaults.
 
     Sets up a project with SmallWebRTC, Deepgram STT, OpenAI LLM, and Cartesia TTS
-    — the fastest way to get a voice agent running.
-
-    Examples:
-        pc init quickstart
-        pc init quickstart -o /path/to/output
+    — the fastest way to get a voice agent running. Dispatched from ``init_command``
+    when the target is ``quickstart`` (e.g. ``pc init quickstart [-o DIR]``).
     """
     try:
         project_name = "pipecat-quickstart"

--- a/src/pipecat_cli/generators/project.py
+++ b/src/pipecat_cli/generators/project.py
@@ -69,23 +69,51 @@ class ProjectGenerator:
 
             # If still exists, loop will continue and prompt again
 
-    def generate(self, output_dir: Path | None = None, non_interactive: bool = False) -> Path:
+    def generate(
+        self,
+        output_dir: Path | None = None,
+        non_interactive: bool = False,
+        in_place: bool = False,
+    ) -> Path:
         """
         Generate the complete project structure.
 
         Args:
-            output_dir: Optional directory to create project in (defaults to current dir)
+            output_dir: Optional directory to create project in (defaults to current dir).
+                When ``in_place`` is True this is the exact destination; otherwise the
+                project is created in a ``<output_dir>/<project_name>`` subfolder.
             non_interactive: If True, raise FileExistsError instead of prompting
+            in_place: If True, scaffold directly into ``output_dir`` (or the current
+                directory) without nesting under a ``<project_name>`` subfolder.
 
         Returns:
             Path to the created project directory
 
         Raises:
-            FileExistsError: If directory exists and non_interactive is True
+            FileExistsError: If a project already exists at the destination and
+                non_interactive is True
         """
         # Determine output directory
         if output_dir is None:
             output_dir = Path.cwd()
+
+        if in_place:
+            # Scaffold directly into output_dir — no <project_name> subfolder.
+            project_path = output_dir
+            project_path.mkdir(parents=True, exist_ok=True)
+            # Guard against clobbering an existing project. The presence of a server/
+            # directory is our "a project already lives here" signal (cargo-init style).
+            if (project_path / "server").exists():
+                if non_interactive:
+                    raise FileExistsError(
+                        f"A project already exists in {project_path} (found a 'server' directory)"
+                    )
+                console.print(
+                    f"\n[yellow]⚠️  A project already exists in {project_path} "
+                    f"(found a 'server' directory).[/yellow]"
+                )
+                raise KeyboardInterrupt("Project creation cancelled")
+            return self._write_project_files(project_path)
 
         project_path = output_dir / self.config.project_name
 
@@ -99,6 +127,17 @@ class ProjectGenerator:
             self.config.project_name = new_name
             project_path = output_dir / new_name
 
+        return self._write_project_files(project_path)
+
+    def _write_project_files(self, project_path: Path) -> Path:
+        """Create the directory structure and render all project files.
+
+        Args:
+            project_path: The directory the project contents are written into.
+
+        Returns:
+            The same ``project_path``, after all files have been generated.
+        """
         # Create project directory structure
         project_path.mkdir(parents=True, exist_ok=True)
         server_path = project_path / "server"
@@ -441,15 +480,22 @@ class ProjectGenerator:
         content = template.render(**context)
         (project_path / "pcc-deploy.toml").write_text(content, encoding="utf-8")
 
-    def print_next_steps(self, project_path: Path) -> None:
-        """Print next steps for the user."""
+    def print_next_steps(self, project_path: Path, in_place: bool = False) -> None:
+        """Print next steps for the user.
+
+        Args:
+            project_path: The directory the project was created in.
+            in_place: If True, the project was scaffolded into the current directory,
+                so the "cd into your project" step is omitted.
+        """
         console.print("\n[bold green]✨ Project created successfully![/bold green]")
         console.print(f"   [cyan]{project_path}[/cyan]\n")
 
         console.print("[bold]Next steps:[/bold]\n")
-        console.print(
-            f"  • Go to your project: [bold cyan]cd {self.config.project_name}[/bold cyan]"
-        )
+        if not in_place:
+            console.print(
+                f"  • Go to your project: [bold cyan]cd {self.config.project_name}[/bold cyan]"
+            )
 
         # Check if this is Daily PSTN or Twilio + Daily SIP (special handling)
         is_daily_pstn = any(

--- a/src/pipecat_cli/main.py
+++ b/src/pipecat_cli/main.py
@@ -12,7 +12,7 @@ from importlib.metadata import version
 import typer
 from rich.console import Console
 
-from pipecat_cli.commands.init import init_app
+from pipecat_cli.commands.init import init_command
 
 app = typer.Typer(
     name="pipecat",
@@ -22,8 +22,9 @@ app = typer.Typer(
 
 console = Console()
 
-# Register commands
-app.add_typer(init_app, name="init", help="Initialize a new Pipecat project")
+# Register commands. `init` is a plain command (not a sub-Typer group) so it can take an
+# optional positional target path followed by options (e.g. `pc init . --bot-type web`).
+app.command("init", help="Initialize a new Pipecat project")(init_command)
 
 # Load pipecat-cli extensions.
 extensions = []
@@ -37,6 +38,7 @@ extensions.sort(key=lambda x: x[0].lower())
 # Add extensions.
 for name, extension in extensions:
     app.add_typer(extension, name=name)
+
 
 def version_callback(value: bool):
     """Print version and exit."""
@@ -63,6 +65,7 @@ def main(
 ):
     """Pipecat CLI - Build AI voice agents with ease."""
     pass
+
 
 if __name__ == "__main__":
     app()

--- a/src/pipecat_cli/prompts/questions.py
+++ b/src/pipecat_cli/prompts/questions.py
@@ -107,9 +107,13 @@ class ProjectConfig:
     enable_observability: bool = False
 
 
-def ask_project_questions() -> ProjectConfig:
+def ask_project_questions(default_name: str | None = None) -> ProjectConfig:
     """
     Ask user for project configuration through interactive prompts.
+
+    Args:
+        default_name: Optional default for the project name prompt (e.g. the basename
+            of the target directory when scaffolding in place).
 
     Returns:
         ProjectConfig with user's selections
@@ -119,6 +123,7 @@ def ask_project_questions() -> ProjectConfig:
     # Question 1: Project name
     project_name = questionary.text(
         "Project name:",
+        default=default_name or "",
         style=custom_style,
         validate=lambda text: len(text) > 0 or "Project name cannot be empty",
     ).ask()

--- a/tests/test_init_in_place.py
+++ b/tests/test_init_in_place.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for `pc init <target>` in-place scaffolding (e.g. `pc init .`)."""
+
+from typer.testing import CliRunner
+
+from pipecat_cli.main import app
+
+runner = CliRunner()
+
+# A complete non-interactive web/cascade invocation, minus the destination.
+SERVICE_FLAGS = [
+    "--bot-type",
+    "web",
+    "-t",
+    "daily",
+    "-m",
+    "cascade",
+    "--stt",
+    "deepgram_stt",
+    "--llm",
+    "openai_llm",
+    "--tts",
+    "cartesia_tts",
+]
+
+
+def test_init_in_place_writes_into_target_dir(tmp_path):
+    """`pc init <dir> --name ...` scaffolds directly into <dir>, no subfolder."""
+    result = runner.invoke(app, ["init", str(tmp_path), "--name", "demo", *SERVICE_FLAGS])
+    assert result.exit_code == 0, result.output
+
+    assert (tmp_path / "server" / "bot.py").exists()
+    assert (tmp_path / "README.md").exists()
+    # Not nested under the project name.
+    assert not (tmp_path / "demo").exists()
+
+
+def test_init_in_place_derives_name_from_dir(tmp_path):
+    """Without --name, the project name is derived from the target dir basename."""
+    target = tmp_path / "my-derived-bot"
+    target.mkdir()
+    result = runner.invoke(app, ["init", str(target), *SERVICE_FLAGS])
+    assert result.exit_code == 0, result.output
+
+    pyproject = (target / "server" / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'name = "my-derived-bot"' in pyproject
+
+
+def test_init_in_place_preserves_claude_md(tmp_path):
+    """The agent-loop case: an existing CLAUDE.md is untouched."""
+    (tmp_path / "CLAUDE.md").write_text("# guidance", encoding="utf-8")
+    result = runner.invoke(app, ["init", str(tmp_path), "--name", "demo", *SERVICE_FLAGS])
+    assert result.exit_code == 0, result.output
+
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8") == "# guidance"
+    assert (tmp_path / "server" / "bot.py").exists()
+
+
+def test_init_in_place_aborts_on_existing_project(tmp_path):
+    """Refuses to clobber a directory that already contains a project."""
+    (tmp_path / "server").mkdir()
+    result = runner.invoke(app, ["init", str(tmp_path), "--name", "demo", *SERVICE_FLAGS])
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+
+def test_init_target_and_output_are_mutually_exclusive(tmp_path):
+    """Passing both a positional target and -o is an error."""
+    result = runner.invoke(
+        app, ["init", str(tmp_path), "-o", str(tmp_path), "--name", "demo", *SERVICE_FLAGS]
+    )
+    assert result.exit_code == 1
+    assert "not both" in result.output
+
+
+def test_init_no_positional_still_nests(tmp_path):
+    """Non-breaking: without a positional target, the project nests under <name>."""
+    result = runner.invoke(
+        app, ["init", "--name", "nested-bot", "-o", str(tmp_path), *SERVICE_FLAGS]
+    )
+    assert result.exit_code == 0, result.output
+
+    assert (tmp_path / "nested-bot" / "server" / "bot.py").exists()
+
+
+def test_init_quickstart_still_works(tmp_path):
+    """Non-breaking: `pc init quickstart -o DIR` still routes to quickstart."""
+    result = runner.invoke(app, ["init", "quickstart", "-o", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "pipecat-quickstart" / "server" / "bot.py").exists()

--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -645,6 +645,48 @@ def test_project_name_conflict(temp_output_dir):
     # that interactively here. This test just verifies the first generation works.
 
 
+def _inplace_config():
+    return ProjectConfig(
+        project_name="my-inplace-bot",
+        bot_type="web",
+        transports=["daily"],
+        mode="cascade",
+        stt_service="deepgram_stt",
+        llm_service="openai_llm",
+        tts_service="cartesia_tts",
+    )
+
+
+def test_generate_in_place_no_subfolder(temp_output_dir):
+    """in_place=True writes contents directly into output_dir (no <name> subfolder)."""
+    generator = ProjectGenerator(_inplace_config())
+    project_path = generator.generate(output_dir=temp_output_dir, in_place=True)
+
+    assert project_path == temp_output_dir
+    assert (temp_output_dir / "server" / "bot.py").exists()
+    assert (temp_output_dir / "README.md").exists()
+    # The contents are NOT nested under the project name.
+    assert not (temp_output_dir / "my-inplace-bot").exists()
+
+
+def test_generate_in_place_preserves_existing_neutral_files(temp_output_dir):
+    """A pre-existing CLAUDE.md (the agent-loop case) is left untouched."""
+    (temp_output_dir / "CLAUDE.md").write_text("# guidance", encoding="utf-8")
+    generator = ProjectGenerator(_inplace_config())
+    generator.generate(output_dir=temp_output_dir, in_place=True)
+
+    assert (temp_output_dir / "CLAUDE.md").read_text(encoding="utf-8") == "# guidance"
+    assert (temp_output_dir / "server" / "bot.py").exists()
+
+
+def test_generate_in_place_aborts_if_project_exists(temp_output_dir):
+    """in_place refuses to clobber an existing project (server/ present)."""
+    (temp_output_dir / "server").mkdir()
+    generator = ProjectGenerator(_inplace_config())
+    with pytest.raises(FileExistsError):
+        generator.generate(output_dir=temp_output_dir, in_place=True, non_interactive=True)
+
+
 def test_generation_uses_utf8_on_windows_locale(monkeypatch, temp_output_dir):
     """Regression test for pipecat-ai/pipecat#4523.
 


### PR DESCRIPTION
## Summary

Adds an optional positional `TARGET` path to `pc init`. Passing a path — e.g. `pc init .` — scaffolds the project contents **directly into that directory** instead of nesting them under a `<project_name>/` subfolder (the vite/django convention: `npm create vite@latest .`, `django-admin startproject name .`).

This is motivated by the upcoming Pipecat agentic coding loop: a user creates a directory containing `CLAUDE.md` guidance, the agent runs `pc init`, and the project should land in that directory rather than nested one level down (which would otherwise force the agent to `mv`/`rmdir` files around — fragile with hidden files and stray artifacts).

**Non-breaking:** omitting the positional argument keeps the exact current behavior (`<-o or cwd>/<name>/`).

## Behavior

| Invocation | Result |
|---|---|
| `pc init` | Unchanged — `<-o or cwd>/<name>/` subfolder |
| `pc init .` | Scaffold into the current dir; name defaults to the dir basename |
| `pc init ./foo` | Scaffold directly into `./foo` (created if missing) |
| `pc init quickstart [-o DIR]` | Unchanged — runs quickstart defaults |

- The positional `TARGET` is the exact destination; `-o/--output` keeps its legacy "parent dir + name subfolder" meaning. Passing **both** is an error.
- Project name when `TARGET` is given: `--name` if provided, else derived from the target directory's basename. So `--name` is optional in this mode.

## Implementation notes

- **`init` converted from a Typer group to a plain command.** A positional argument on a Click *group* can't be followed by options (parsing stops at the first positional), which would break `pc init . --bot-type web ...`. As a plain command, interspersed options work. The `quickstart` token is dispatched from within `init_command` to preserve `pc init quickstart [-o DIR]`.
- `ProjectGenerator.generate(..., in_place=True)` writes straight into the target, guards against clobbering an existing project (aborts if a `server/` dir is already present), and `print_next_steps` omits the now-irrelevant `cd <name>` step. Shared file-writing logic extracted into `_write_project_files`.

## Testing

- `uv run pytest tests/` → 445 passing.
- New `tests/test_init_in_place.py`: in-place writes, name derivation, `CLAUDE.md` preservation, conflict abort, `target`/`-o` mutual exclusion, and non-breaking regressions (nested layout + quickstart). Plus generator-level `in_place` unit tests.
- Manual: `pc init .` into a dir holding `CLAUDE.md` → flat layout (`server/`, `README.md`, `.gitignore`), `CLAUDE.md` untouched, name derived from the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)